### PR TITLE
ci(.github): only run CI workflow on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
In preparation for replacing this workflow.