### PR TITLE
fix: add homebrew to PATH on darwin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
         run: |
           ssh ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }} <<'EOF'
             if [[ "${{ github.event.inputs.os }}" == darwin ]]; then
+              export PATH="/opt/homebrew/bin:$PATH"
               export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=11.7 --host_copt=-mmacos-version-min=11.7"
             fi
             git clone https://github.com/kumahq/kuma && cd kuma


### PR DESCRIPTION
`arm64` and `amd64` install `homebrew` packages to different locations, apparently. And when we run `ssh` like this, the command is executed directly so there's no sourcing of `~/.bashrc` or anywhere where `homebrew` will have added its `bin` to `$PATH.

When we move the envoy builds scripts into this repo we can clean all of this up.