### PR TITLE
chore(deps): upgrade provider version

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,7 +53,7 @@ provider "aws" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "3.19.0"
+  version = "5.0.0"
 
   name = "envoy-ci-${var.os}-${var.arch}"
   cidr = "10.0.0.0/16"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.67.0"
+    }
+  }
+}
+
 variable "public_key_path" {
   type        = string
   description = "Path to public key for creating a key pair"
@@ -53,7 +62,7 @@ provider "aws" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "5.0.0"
+  version = "3.19.0"
 
   name = "envoy-ci-${var.os}-${var.arch}"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
With the newer version of terraform build fails because of https://github.com/terraform-aws-modules/terraform-aws-vpc/releases. In 5.0.0 value was removed.

<img width="763" alt="image" src="https://github.com/kumahq/envoy-builds/assets/13002762/42d5ae0f-26b4-426d-8bb8-307542944e9f">
