### PR TITLE
docs(windows): added target to windows build command

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -32,7 +32,7 @@ cd /c
 git clone https://github.com/envoyproxy/envoy.git
 cd envoy
 git checkout <ENVOY_VERSION> # Envoy's version e.g.: git checkout v1.26.0
-TEMP=C: ./ci/run_envoy_docker.sh './ci/windows_ci_steps.sh'
+TEMP=C: ./ci/run_envoy_docker.sh './ci/windows_ci_steps.sh //source/exe:envoy-static'
 ```
 
 ### Retrieving binary


### PR DESCRIPTION
When you provide a target `//source/exe:envoy-static` to the build script it won't build tests and build takes much less time.