### PR TITLE
fix(darwin/amd64): remove /usr/local/include/openssl to pass the build

### DIFF
--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -25,6 +25,7 @@ BAZEL_BUILD_OPTIONS=(
 
 read -ra CONTRIB_ENABLED_ARGS <<< "$(python "${CONTRIB_ENABLED_MATRIX_SCRIPT}")"
 
+rm -rf /usr/local/include/openssl
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //contrib/exe:envoy-static "${CONTRIB_ENABLED_ARGS[@]}"
 
 popd

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -15,6 +15,7 @@ sudo -u ec2-user -i <<SUDOEOF
 echo "alias python=python3" >> ~/.bash_profile
 # Using && is apparently necessary to ensure touch runs. Do not modify without testing!
 brew install automake cmake coreutils libtool wget ninja go && brew reinstall --force bazelisk && touch ~/ready
+rm -rf /usr/local/include/openssl
 SUDOEOF
 EOF
 }

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -15,7 +15,6 @@ sudo -u ec2-user -i <<SUDOEOF
 echo "alias python=python3" >> ~/.bash_profile
 # Using && is apparently necessary to ensure touch runs. Do not modify without testing!
 brew install automake cmake coreutils libtool wget ninja go && brew reinstall --force bazelisk && touch ~/ready
-rm -rf /usr/local/include/openssl
 SUDOEOF
 EOF
 }


### PR DESCRIPTION
It's not clear yet why suddenly builds of Envoy for darwin/amd64 started to fail. It's not connected to image version(ami) because I've tried the same as we used previously with the previous envoy version that succeded but now it doesn't work. 

I've found out that after installation of wget in `/usr/local/include/` there is a link to `openssl` linking headers files. That causes that during envoy build, bazel takes these header files to build external dependencies. These header files are newer than the dependency is using and that is causing the error. Something in the installation of the dependency has changed.