### PR TITLE
docs(glibc): add instructions on patching Envoy with glibc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ Below are instructions on how to run Envoy with a custom glibc:
 envoy     readme.md src       usr
 ```
 3. Use `patchelf` to patch the binary:
-   1. Installed by package manage (e.g. `apt-get install patchelf`)
+
+3.1. Installed by package manage (e.g. `apt-get install patchelf`)
+
 ```shell
 patchelf --set-interpreter usr/glibc-compat/lib/ld-linux-x86-64.so.2 --set-rpath usr/glibc-compat/lib/ envoy
 ```
-   2. Using docker
+
+3.2. Using docker
 ```shell
 docker run -v .:/envoy -w /envoy --platform linux/amd64 -it onedata/patchelf:0.9 --set-interpreter usr/glibc-compat/lib/ld-linux-x86-64.so.2 --set-rpath usr/glibc-compat/lib/ envoy
 ```

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Below are instructions on how to run Envoy with a custom glibc:
 envoy     readme.md src       usr
 ```
 3. Use `patchelf` to patch the binary:
-    1. Installed by package manage (e.g. `apt-get install patchelf`)
+   1. Installed by package manage (e.g. `apt-get install patchelf`)
 ```shell
 patchelf --set-interpreter usr/glibc-compat/lib/ld-linux-x86-64.so.2 --set-rpath usr/glibc-compat/lib/ envoy
 ```
-2. Using docker
+   2. Using docker
 ```shell
 docker run -v .:/envoy -w /envoy --platform linux/amd64 -it onedata/patchelf:0.9 --set-interpreter usr/glibc-compat/lib/ld-linux-x86-64.so.2 --set-rpath usr/glibc-compat/lib/ envoy
 ```


### PR DESCRIPTION
Instead of https://github.com/kumahq/envoy-builds/pull/37

proof that it passes e2e tests: https://github.com/kumahq/kuma/pull/7592

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
