### PR TITLE
fix(terraform): update aws ssm parameter for windows ami

### DIFF
--- a/terraform/windows.tf
+++ b/terraform/windows.tf
@@ -1,3 +1,3 @@
 data "aws_ssm_parameter" "windows" {
-  name = "/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ContainersLatest"
+  name = "/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized/image_id"
 }


### PR DESCRIPTION
`/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ContainersLatest` doesn't exist anymore.

I tested the new one with building envoy v1.25.10 and it succeeded.

It fixes: https://github.com/kumahq/envoy-builds/actions/runs/6478558480/job/17590518809

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
