### PR TITLE
ci(macos): update macos to v12

### DIFF
--- a/terraform/find-or-create-host.sh
+++ b/terraform/find-or-create-host.sh
@@ -33,9 +33,11 @@ if [[ $hostID == "" ]]; then
         --tag-specifications 'ResourceType=dedicated-host,Tags=[{Key=EnvoyCI,Value=true}]' | \
         jq -r .HostIds[0]
     )
-fi 
+fi
 echo "Creating terraform.tfvars with host $hostID"
 
-cat <<EOF > terraform.tfvars
+sed -i '' -e '/host_id/d' terraform.tfvars 2>/dev/null || true
+
+cat <<EOF >> terraform.tfvars
 host_id = "$hostID"
 EOF

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -25,7 +25,7 @@ data "aws_ami" "mac" {
   filter {
     name = "name"
     values = [
-      "amzn-ec2-macos-11.*.*-*-*"
+      "amzn-ec2-macos-12.*.*-*-*"
     ]
   }
   filter {


### PR DESCRIPTION
We have problems building envoy on macOS 11 and according to envoy team, the latest envoy (v1.29.0) builds on macOS 12.

- [x] Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
- [x] Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
