### PR TITLE
chore(windows): install docker and reduce vm size

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ locals {
       arm64 = "c7g.4xlarge"
     }
     windows = {
-      amd64 = "c6i.8xlarge"
+      amd64 = "c6i.4xlarge"
     }
   }
   user_data = {

--- a/terraform/windows.tf
+++ b/terraform/windows.tf
@@ -28,6 +28,10 @@ locals {
   # Install Git using Chocolatey
   choco install -y git.portable
   C:\tools\git\bin\git.exe clone https://github.com/envoyproxy/envoy.git C:/envoy
+
+  # Install Docker
+  Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -o "C:/install-docker-ce.ps1"
+  Invoke-Expression "C:\install-docker-ce.ps1"
 </powershell>
 EOF
 

--- a/terraform/windows.tf
+++ b/terraform/windows.tf
@@ -1,5 +1,5 @@
 data "aws_ssm_parameter" "windows" {
-  name = "/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-1.23/image_id"
+  name = "/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-1.29/image_id"
 }
 
 locals {


### PR DESCRIPTION
I've tried to use Base/Core image but they don't enable container feature by default. When I enable it it triggers VM restart which is not a good thing in CI. I am using ECS image which has feature enable and just install docker to make build works