### PR TITLE
fix(darwin): remove pip3 install virtualenv

### DIFF
--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -9,8 +9,6 @@ locals {
 #!/bin/bash
 set -e
 
-pip3 install virtualenv
-
 sudo -u ec2-user -i <<SUDOEOF
 # Using && is apparently necessary to ensure touch runs. Do not modify without testing!
 brew install bash automake cmake coreutils libtool wget ninja go && brew reinstall --force bazelisk && touch ~/ready


### PR DESCRIPTION
Otherwise we see errors from the userdata on startup:

```
× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
```

Fixes _maybe_ https://github.com/kumahq/envoy-builds/issues/41