### PR TITLE
fix: support building any version on default branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,11 +94,6 @@ jobs:
           else
             echo "SSH_USER=ec2-user" >> $GITHUB_ENV
           fi
-          if [[ "${{ inputs.os }}" == darwin ]]; then
-            if [[ "${{ inputs.version }}" == "1.26"* ]]; then
-              echo "macos_version = 11" >> terraform.tfvars
-            fi
-          fi
       - run: terraform apply -input=false -auto-approve
         working-directory: terraform
         id: terraform-apply

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,11 @@ jobs:
           else
             echo "SSH_USER=ec2-user" >> $GITHUB_ENV
           fi
+          if [[ "${{ inputs.os }}" == darwin ]]; then
+            if [[ "${{ inputs.version }}" == "1.26"* ]]; then
+              echo "macos_version = 11" >> terraform.tfvars
+            fi
+          fi
       - run: terraform apply -input=false -auto-approve
         working-directory: terraform
         id: terraform-apply

--- a/scripts/dns_filter_resolver.h.patch
+++ b/scripts/dns_filter_resolver.h.patch
@@ -1,0 +1,30 @@
+diff --git a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+index 4dbd364b59..49b6d90e5f 100644
+--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
++++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+@@ -24,9 +24,9 @@ public:
+                     const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config,
+                     const Network::DnsResolverFactory& dns_resolver_factory, Api::Api& api)
+       : timeout_(timeout), dispatcher_(dispatcher),
++        callback_(callback), max_pending_lookups_(max_pending_lookups),
+         resolver_(
+-            dns_resolver_factory.createDnsResolver(dispatcher, api, typed_dns_resolver_config)),
+-        callback_(callback), max_pending_lookups_(max_pending_lookups) {}
++            dns_resolver_factory.createDnsResolver(dispatcher, api, typed_dns_resolver_config)) {}
+   /**
+    * @brief entry point to resolve the name in a DnsQueryRecord
+    *
+@@ -66,10 +66,12 @@ private:
+
+   std::chrono::milliseconds timeout_;
+   Event::Dispatcher& dispatcher_;
+-  const Network::DnsResolverSharedPtr resolver_;
+   DnsFilterResolverCallback& callback_;
+   absl::flat_hash_map<const DnsQueryRecord*, LookupContext> lookups_;
+   uint64_t max_pending_lookups_;
++
++  // we need resolver_'s destructor to run first, because DnsFilterResolver has callback that's using lookups_
++  const Network::DnsResolverSharedPtr resolver_;
+ };
+
+ using DnsFilterResolverPtr = std::unique_ptr<DnsFilterResolver>;

--- a/scripts/fetch_sources.sh
+++ b/scripts/fetch_sources.sh
@@ -11,9 +11,9 @@ set -o pipefail
 set -o nounset
 
 PATCH_FILES_1_26=(
-  $(realpath "scripts/dns_filter_resolver.h.patch")
-  $(realpath "scripts/filter_test.cc.patch")
-  $(realpath "scripts/rbac_filter.cc.patch")
+  "$(realpath "scripts/dns_filter_resolver.h.patch")"
+  "$(realpath "scripts/filter_test.cc.patch")"
+  "$(realpath "scripts/rbac_filter.cc.patch")"
 )
 
 DARWIN_PATCH_FILE=$(realpath "scripts/luajit.patch.patch")

--- a/scripts/filter_test.cc.patch
+++ b/scripts/filter_test.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/test/extensions/filters/network/rbac/filter_test.cc b/test/extensions/filters/network/rbac/filter_test.cc
+index cffdf4c03e..38555e2aaf 100644
+--- a/test/extensions/filters/network/rbac/filter_test.cc
++++ b/test/extensions/filters/network/rbac/filter_test.cc
+@@ -319,7 +319,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, Denied) {
+   setDestinationPort(456);
+   setMetadata();
+ 
+-  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush)).Times(2);
++  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _)).Times(2);
+ 
+   // Call onData() twice, should only increase stats once.
+   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+@@ -424,7 +424,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, MatcherDenied) {
+   setDestinationPort(456);
+   setMetadata();
+ 
+-  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush)).Times(2);
++  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _)).Times(2);
+ 
+   // Call onData() twice, should only increase stats once.
+   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data_, false));

--- a/scripts/rbac_filter.cc.patch
+++ b/scripts/rbac_filter.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/source/extensions/filters/network/rbac/rbac_filter.cc b/source/extensions/filters/network/rbac/rbac_filter.cc
+index 86698dd239..500a0c2f61 100644
+--- a/source/extensions/filters/network/rbac/rbac_filter.cc
++++ b/source/extensions/filters/network/rbac/rbac_filter.cc
+@@ -118,7 +118,7 @@ Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bo
+   } else if (engine_result_ == Deny) {
+     callbacks_->connection().streamInfo().setConnectionTerminationDetails(
+         Filters::Common::RBAC::responseDetail(log_policy_id));
+-    callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
++    callbacks_->connection().close(Network::ConnectionCloseType::NoFlush, "rbac_deny_close");
+     return Network::FilterStatus::StopIteration;
+   }
+ 

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -4,13 +4,8 @@ variable "host_id" {
   description = "Dedicated host id for building on Darwin"
 }
 
-variable "macos_version" {
-  type = number
-  default = 12
-  description = "If using Darwin, which macos major version to use"
-}
-
 locals {
+    macos_version = startswith(var.envoy_version, "1.26") ? 11 : 12
     macos_user_data = <<EOF
 #!/bin/bash
 set -e
@@ -29,7 +24,7 @@ data "aws_ami" "mac" {
   filter {
     name = "name"
     values = [
-      "amzn-ec2-macos-${var.macos_version}.*.*-*-*"
+      "amzn-ec2-macos-${local.macos_version}.*.*-*-*"
     ]
   }
   filter {

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -1,12 +1,16 @@
 variable "host_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Dedicated host id for building on Darwin"
 }
 
 locals {
-    macos_version = startswith(var.envoy_version, "1.26") ? 11 : 12
-    macos_user_data = <<EOF
+  macos_version = (
+    startswith(var.envoy_version, "1.26")
+    || startswith(var.envoy_version, "1.27")
+    || startswith(var.envoy_version, "1.28")
+  ) ? 11 : 12
+  macos_user_data = <<EOF
 #!/bin/bash
 set -e
 

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -4,12 +4,19 @@ variable "host_id" {
   description = "Dedicated host id for building on Darwin"
 }
 
+variable "macos_version" {
+  type = number
+  default = 12
+  description = "If using Darwin, which macos major version to use"
+}
+
 locals {
     macos_user_data = <<EOF
 #!/bin/bash
 set -e
 
 sudo -u ec2-user -i <<SUDOEOF
+echo "alias python=python3" >> ~/.bash_profile
 # Using && is apparently necessary to ensure touch runs. Do not modify without testing!
 brew install bash automake cmake coreutils libtool wget ninja go && brew reinstall --force bazelisk && touch ~/ready
 SUDOEOF
@@ -22,7 +29,7 @@ data "aws_ami" "mac" {
   filter {
     name = "name"
     values = [
-      "amzn-ec2-macos-12.*.*-*-*"
+      "amzn-ec2-macos-${var.macos_version}.*.*-*-*"
     ]
   }
   filter {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ variable "fips" {
 
 variable "envoy_version" {
   type        = string
-  description = "Envoy version"
+  description = "Envoy version, not prefixed with v"
   default     = "main"
 }
 


### PR DESCRIPTION
This takes the changes from release-1.26 and applies them depending on `inputs.version`