### PR TITLE
ci(.github): run build and release before project report

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -16,7 +16,7 @@ on:
         type: boolean
         required: false
   schedule:
-    - cron: 0 6 * * 1
+    - cron: 0 4 * * 1
 
 permissions:
   id-token: write


### PR DESCRIPTION
Let's do this a little earlier.