### PR TITLE
chore(gha): fix action to skip build on no change

### DIFF
--- a/.github/workflows/release-on-schedule.yaml
+++ b/.github/workflows/release-on-schedule.yaml
@@ -49,7 +49,7 @@ jobs:
 
   trigger-release:
     uses: ./.github/workflows/build-and-release.yaml
-    if: ${{ needs.get-envoy-versions.outputs.versions_to_release != '[]' }}
+    if: ${{ needs.get-envoy-versions.outputs.versions_to_release != '[""]' }}
     needs: get-envoy-versions
     strategy:
       max-parallel: 1 # lets build one version at the time - potential issue, if more jobs try to run at the same time they might try to allocate host that is used by other job and fail build


### PR DESCRIPTION
We were missing `""` and didn't skip the job when no release