### PR TITLE
ci(mac): use osx 14 and newer compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,12 @@ jobs:
         run: |
           ssh -i ~/.ssh/id_aws ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }} <<'EOF'
             set -e
-            if [[ "${{ inputs.os }}" == darwin && "${{ inputs.version }}" == "main" ]]; then
+            minor_version=""
+            if [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              # If the version string matches a numeric format (X.Y or X.Y.Z)
+              minor_version=$(echo "${{ inputs.version }}" | cut -d'.' -f2)
+            fi
+            if [[ "${{ inputs.os }}" == "darwin" && ( "${{ inputs.version }}" == "main" || ( -n "$minor_version" && "$minor_version" -gt "34" )) ]]; then
               export PATH="/opt/homebrew/bin:$PATH"
               export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"
             fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,11 @@ jobs:
         run: |
           ssh -i ~/.ssh/id_aws ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }} <<'EOF'
             set -e
-            if [[ "${{ inputs.os }}" == darwin ]]; then
+            if [[ "${{ inputs.os }}" == darwin && "${{ inputs.version }}" == "main" ]]; then
+              export PATH="/opt/homebrew/bin:$PATH"
+              export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"
+            fi
+            if [[ "${{ inputs.os }}" == darwin && "${{ inputs.version }}" != "main" ]]; then
               export PATH="/opt/homebrew/bin:$PATH"
               export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=12.7 --host_copt=-mmacos-version-min=12.7"
             fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,7 +137,7 @@ jobs:
               export PATH="/opt/homebrew/bin:$PATH"
               export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"
             fi
-            if [[ "${{ inputs.os }}" == darwin && "${{ inputs.version }}" != "main" ]]; then
+            if [[ "${{ inputs.os }}" == darwin && "${{ inputs.version }}" != "main" && ( -n "$minor_version" && "$minor_version" -lt "35" ) ]]; then
               export PATH="/opt/homebrew/bin:$PATH"
               export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=12.7 --host_copt=-mmacos-version-min=12.7"
             fi

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -10,7 +10,7 @@ locals {
     || startswith(var.envoy_version, "1.32")
     || startswith(var.envoy_version, "1.33")
     || startswith(var.envoy_version, "1.34")
-  ) ? 12 : 13
+  ) ? 12 : 14
   macos_user_data = <<EOF
 #!/bin/bash
 set -e

--- a/terraform/macos.tf
+++ b/terraform/macos.tf
@@ -6,10 +6,11 @@ variable "host_id" {
 
 locals {
   macos_version = (
-    startswith(var.envoy_version, "1.26")
-    || startswith(var.envoy_version, "1.27")
-    || startswith(var.envoy_version, "1.28")
-  ) ? 11 : 12
+    startswith(var.envoy_version, "1.31")
+    || startswith(var.envoy_version, "1.32")
+    || startswith(var.envoy_version, "1.33")
+    || startswith(var.envoy_version, "1.34")
+  ) ? 12 : 13
   macos_user_data = <<EOF
 #!/bin/bash
 set -e


### PR DESCRIPTION
We need probably better version check since we should use `--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"` for version main and newer