### PR TITLE
ci(security): prevent template injection

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -83,7 +83,9 @@ jobs:
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      - run: |
+      - env:
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
           mkdir out
           for dir in envoy*; do
             IFS=- read -r envoy os arch version fips <<< "${dir}"
@@ -91,7 +93,7 @@ jobs:
               chmod +x "${bin}"
 
               bin="$(basename "${bin}")"
-              archive_name="envoy-${os}-${arch}-v${version}${{ inputs.suffix }}"
+              archive_name="envoy-${os}-${arch}-v${version}${SUFFIX}"
               if [[ "${fips}" == "true" ]]; then
                 archive_name="${archive_name}+fips"
               fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,7 +166,7 @@ jobs:
           SCRIPT
 
           # Upload and execute build script with safely-quoted env vars
-          scp -i ~/.ssh/id_aws /tmp/build-envoy.sh "${SSH_USER}@${PUBLIC_IP}:/tmp/build-envoy.sh"
+          scp -i ~/.ssh/id_aws -o StrictHostKeyChecking=accept-new /tmp/build-envoy.sh "${SSH_USER}@${PUBLIC_IP}:/tmp/build-envoy.sh"
           ssh -i ~/.ssh/id_aws "${SSH_USER}@${PUBLIC_IP}" \
             "$(printf 'export VERSION=%q INPUT_OS=%q INPUT_ARCH=%q FIPS=%q REPO=%q REPO_OWNER=%q COMMIT_SHA=%q;' \
               "$VERSION" "$INPUT_OS" "$INPUT_ARCH" "$FIPS" "$REPO" "$REPO_OWNER" "$COMMIT_SHA") bash /tmp/build-envoy.sh"
@@ -177,7 +177,7 @@ jobs:
           PUBLIC_IP: ${{ steps.public-ip.outputs.stdout }}
         run: |
             envoy_dir="~/build/artifacts-${INPUT_OS}-${INPUT_ARCH}/envoy"
-            scp -i ~/.ssh/id_aws -o StrictHostKeyChecking=no -r "${SSH_USER}@${PUBLIC_IP}:${envoy_dir}" .
+            scp -i ~/.ssh/id_aws -o StrictHostKeyChecking=accept-new -r "${SSH_USER}@${PUBLIC_IP}:${envoy_dir}" .
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: envoy-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.version }}-${{ inputs.fips }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,20 +76,27 @@ jobs:
       - name: Find Mac OS dedicated host
         if: inputs.os == 'darwin'
         working-directory: terraform
+        env:
+          ARCH: ${{ inputs.arch }}
         run: |
-          ./find-or-create-host.sh '${{ inputs.arch }}'
+          ./find-or-create-host.sh "$ARCH"
       - name: Set terraform variables
         working-directory: terraform
+        env:
+          ARCH: ${{ inputs.arch }}
+          OS: ${{ inputs.os }}
+          FIPS: ${{ inputs.fips }}
+          VERSION: ${{ inputs.version }}
         run: |
           cat <<EOF >> terraform.tfvars
           public_key_path = "~/.ssh/id_aws.pub"
-          arch = "${{ inputs.arch }}"
-          os = "${{ inputs.os }}"
-          fips = ${{ inputs.fips }}
-          envoy_version = "${{ inputs.version }}"
+          arch = "${ARCH}"
+          os = "${OS}"
+          fips = ${FIPS}
+          envoy_version = "${VERSION}"
           EOF
 
-          if [[ "${{ inputs.os }}" == linux ]]; then
+          if [[ "${OS}" == linux ]]; then
             echo "SSH_USER=admin" >> $GITHUB_ENV
           else
             echo "SSH_USER=ec2-user" >> $GITHUB_ENV
@@ -108,48 +115,69 @@ jobs:
       - name: Wait for VM to be ready
         working-directory: terraform
         timeout-minutes: 90
+        env:
+          PUBLIC_IP: ${{ steps.public-ip.outputs.stdout }}
         run: |
-          while ! timeout 10 ssh -i ~/.ssh/id_aws -o BatchMode=yes -o StrictHostKeyChecking=accept-new ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }} 'test -e ready'
+          while ! timeout 10 ssh -i ~/.ssh/id_aws -o BatchMode=yes -o StrictHostKeyChecking=accept-new "${SSH_USER}@${PUBLIC_IP}" 'test -e ready'
           do
             sleep 5
           done
       - name: Build Envoy
+        env:
+          VERSION: ${{ inputs.version }}
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_ARCH: ${{ inputs.arch }}
+          FIPS: ${{ inputs.fips }}
+          REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          COMMIT_SHA: ${{ github.sha }}
+          PUBLIC_IP: ${{ steps.public-ip.outputs.stdout }}
         run: |
-          ssh -i ~/.ssh/id_aws ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }} <<'EOF'
-            set -e
-            minor_version=""
-            if [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-              # If the version string matches a numeric format (X.Y or X.Y.Z)
-              minor_version=$(echo "${{ inputs.version }}" | cut -d'.' -f2)
+          # Write build script to temp file (single-quoted heredoc prevents expansion)
+          cat > /tmp/build-envoy.sh <<'SCRIPT'
+          set -e
+          minor_version=""
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            # If the version string matches a numeric format (X.Y or X.Y.Z)
+            minor_version=$(echo "$VERSION" | cut -d'.' -f2)
+          fi
+          if [[ "$INPUT_OS" == "darwin" ]]; then
+            export PATH="/opt/homebrew/bin:$PATH"
+            if [[ "$VERSION" == "main" || ( -n "$minor_version" && "$minor_version" -gt "34" ) ]]; then
+              BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"
+              [[ "$INPUT_ARCH" == "amd64" ]] && BAZEL_BUILD_EXTRA_OPTIONS+=" --repo_env=BAZEL_LLVM_PATH=/usr/local/Cellar/llvm@18/18.1.8/"
+              export BAZEL_BUILD_EXTRA_OPTIONS
+            elif [[ -n "$minor_version" && "$minor_version" -lt "35" ]]; then
+              export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=12.7 --host_copt=-mmacos-version-min=12.7"
             fi
-            if [[ "${{ inputs.os }}" == "darwin" ]]; then
-              export PATH="/opt/homebrew/bin:$PATH"
-              if [[ "${{ inputs.version }}" == "main" || ( -n "$minor_version" && "$minor_version" -gt "34" ) ]]; then
-                BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=13.3 --host_copt=-mmacos-version-min=13.3"
-                [[ "${{ inputs.arch }}" == "amd64" ]] && BAZEL_BUILD_EXTRA_OPTIONS+=" --repo_env=BAZEL_LLVM_PATH=/usr/local/Cellar/llvm@18/18.1.8/"
-                export BAZEL_BUILD_EXTRA_OPTIONS
-              elif [[ -n "$minor_version" && "$minor_version" -lt "35" ]]; then
-                export BAZEL_BUILD_EXTRA_OPTIONS="--copt=-mmacos-version-min=12.7 --host_copt=-mmacos-version-min=12.7"
-              fi
-            fi
+          fi
 
-            export ENVOY_VERSION="${{ inputs.version }}"
-            REPO="${{ github.repository }}"
-            git clone "https://github.com/$REPO" && cd "${REPO#${{ github.repository_owner }}/}"
-            git checkout ${{ github.sha }}
+          export ENVOY_VERSION="$VERSION"
+          git clone "https://github.com/$REPO" && cd "${REPO#${REPO_OWNER}/}"
+          git checkout "$COMMIT_SHA"
 
-            if [[ ${{ inputs.fips }} == true ]]; then
-              make build/envoy/fips
-            else
-              make build/envoy
-            fi
+          if [[ "$FIPS" == true ]]; then
+            make build/envoy/fips
+          else
+            make build/envoy
+          fi
 
-            mv build ..
-          EOF
+          mv build ..
+          SCRIPT
+
+          # Upload and execute build script with safely-quoted env vars
+          scp -i ~/.ssh/id_aws /tmp/build-envoy.sh "${SSH_USER}@${PUBLIC_IP}:/tmp/build-envoy.sh"
+          ssh -i ~/.ssh/id_aws "${SSH_USER}@${PUBLIC_IP}" \
+            "$(printf 'export VERSION=%q INPUT_OS=%q INPUT_ARCH=%q FIPS=%q REPO=%q REPO_OWNER=%q COMMIT_SHA=%q;' \
+              "$VERSION" "$INPUT_OS" "$INPUT_ARCH" "$FIPS" "$REPO" "$REPO_OWNER" "$COMMIT_SHA") bash /tmp/build-envoy.sh"
       - name: Download Envoy binaries
+        env:
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_ARCH: ${{ inputs.arch }}
+          PUBLIC_IP: ${{ steps.public-ip.outputs.stdout }}
         run: |
-            envoy_dir="~/build/artifacts-${{ inputs.os }}-${{ inputs.arch }}/envoy"
-            scp -i ~/.ssh/id_aws -o StrictHostKeyChecking=no -r ${{ env.SSH_USER }}@${{ steps.public-ip.outputs.stdout }}:${envoy_dir} .
+            envoy_dir="~/build/artifacts-${INPUT_OS}-${INPUT_ARCH}/envoy"
+            scp -i ~/.ssh/id_aws -o StrictHostKeyChecking=no -r "${SSH_USER}@${PUBLIC_IP}:${envoy_dir}" .
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: envoy-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.version }}-${{ inputs.fips }}

--- a/.github/workflows/release-on-schedule.yaml
+++ b/.github/workflows/release-on-schedule.yaml
@@ -32,9 +32,10 @@ jobs:
         run: |
           versions_to_release=()
           read -ra envoy_versions <<< "$ENVOY_VERSIONS"
+          released_versions=$(gh api repos/kumahq/envoy-builds/releases --paginate --jq '.[].tag_name')
           for envoy_version in "${envoy_versions[@]}"; do
             echo "Checking if $envoy_version has been already released"
-            version=$(gh api repos/kumahq/envoy-builds/releases --jq ".[] | select(.tag_name == \"$envoy_version\") | .tag_name")
+            version=$(grep -Fx -- "$envoy_version" <<< "$released_versions" || true)
             if [ -z "$version" ]; then
               echo "No version found for $envoy_version"
               version_without_v=$(echo "$envoy_version" | sed 's/^v//')

--- a/.github/workflows/release-on-schedule.yaml
+++ b/.github/workflows/release-on-schedule.yaml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Get Envoy versions to release
         id: get-versions-to-release
+        env:
+          ENVOY_VERSIONS: ${{ steps.check-envoy-released-versions.outputs.envoy_versions }}
         run: |
           versions_to_release=()
-          eval "envoy_versions=(${{ steps.check-envoy-released-versions.outputs.envoy_versions }})"
+          read -ra envoy_versions <<< "$ENVOY_VERSIONS"
           for envoy_version in "${envoy_versions[@]}"; do
             echo "Checking if $envoy_version has been already released"
             version=$(gh api repos/kumahq/envoy-builds/releases --jq ".[] | select(.tag_name == \"$envoy_version\") | .tag_name")


### PR DESCRIPTION
## Motivation

Aikido security scan flagged multiple GitHub Actions workflows for template expression injection. Interpolating `${{ }}` expressions directly in `run:` blocks lets untrusted input execute shell commands in the CI/CD pipeline.

## Implementation information

For local steps, move `${{ }}` expressions to step-level `env:` blocks and reference them as shell variables.

For the remote SSH build step in `build.yaml`, write the script to a temp file via single-quoted heredoc (no expansion), scp it to the remote, then execute it with `printf '%q'`-escaped env vars passed through the SSH command. This handles shell metacharacters in values.

In `release-on-schedule.yaml`, replace the unsafe `eval "array=(${{ output }})"` with `read -ra array <<< "$ENV_VAR"`.