### PR TITLE
chore(build): apply patch for 1.38

### DIFF
--- a/.github/workflows/build-github.yaml
+++ b/.github/workflows/build-github.yaml
@@ -140,6 +140,12 @@ jobs:
             fi
           fi
 
+          # v1.38+ introduced dynamic_modules/builtin_extensions (hickory DNS resolver) which
+          # requires @llvm_toolchain_llvm that is not available on macOS builds
+          if [[ "$VERSION" == "main" || ( -n "$minor_version" && "$minor_version" -ge "38" ) ]]; then
+            BAZEL_BUILD_EXTRA_OPTIONS+=" --//source/extensions/network/dns_resolver/hickory:enabled=false"
+          fi
+
           echo "BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS}" >> "$GITHUB_ENV"
 
       - name: Build Envoy

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ endif
 FIPS_BAZEL_OPTION := --define boringssl=fips
 ifeq ($(ENVOY_VERSION),main)
 	FIPS_BAZEL_OPTION := --config=boringssl-fips
+else ifeq ($(shell echo "$(ENVOY_VERSION)" | awk -F. '{print ($$2+0 >= 38)}'),1)
+	FIPS_BAZEL_OPTION := --config=boringssl-fips
 endif
 
 .PHONY: build/envoy/fips

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -18,7 +18,7 @@ patch_per_version[v1.34]="$()"
 patch_per_version[v1.35]="$()"
 patch_per_version[v1.36]="$()"
 patch_per_version[v1.37]="$(realpath "patches/main-0001-linux-dockerfile-build-ubuntu.patch")"
-patch_per_version[v1.38]="$()"
+patch_per_version[v1.38]="$(realpath "patches/main-0001-linux-dockerfile-build-ubuntu.patch")"
 
 BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:-""}
 read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS}"


### PR DESCRIPTION
  1. Linux (amd64/arm64/FIPS): bazel/setup_clang.sh was removed from Envoy source before v1.37, but patch_per_version[v1.38] was left empty — the Dockerfile still runs this non-existent script.
  2. Darwin (amd64, arm64 likely same): Envoy v1.38 added source/extensions/dynamic_modules/builtin_extensions (the hickory DNS resolver via Rust), which uses
  @llvm_toolchain_llvm//:objcopy for symbol renaming. The @@llvm_toolchain_llvm Bazel repository isn't created on macOS when using a local LLVM installation via BAZEL_LLVM_PATH. Envoy's own macOS CI sidesteps this by using a limited build config that excludes hickory.