### PR TITLE
fix(build): image rename

### DIFF
--- a/patches/main-0001-linux-dockerfile-build-ubuntu.patch
+++ b/patches/main-0001-linux-dockerfile-build-ubuntu.patch
@@ -1,11 +1,10 @@
 diff --git a/scripts/Dockerfile.build-ubuntu b/scripts/Dockerfile.build-ubuntu
-index ec6f185..6fb02f6 100644
 --- a/scripts/Dockerfile.build-ubuntu
 +++ b/scripts/Dockerfile.build-ubuntu
-@@ -12,6 +12,5 @@ RUN groupadd --gid 777 -f envoygroup \
- 
+@@ -17,6 +17,5 @@ RUN groupadd --gid 777 -f envoygroup \
+
  COPY --chown=envoybuild:envoygroup . /envoy-sources/
- 
+
 -RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && bazel/setup_clang.sh /opt/llvm"
  RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && $BUILD_CMD"
  RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources/bazel-bin/contrib/exe && strip envoy-static -o envoy"

--- a/scripts/Dockerfile.build-centos
+++ b/scripts/Dockerfile.build-centos
@@ -3,6 +3,11 @@ FROM $ENVOY_BUILD_IMAGE
 
 ARG BUILD_CMD
 
+# binutils (strip) is not in the ci-variant build images shipped from v1.37+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends binutils \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY . /envoy-sources/
 
 RUN bash -c "pushd envoy-sources/ && bazel/setup_clang.sh /opt/llvm"

--- a/scripts/Dockerfile.build-ubuntu
+++ b/scripts/Dockerfile.build-ubuntu
@@ -5,9 +5,9 @@ ARG BUILD_CMD
 
 # since 1.27.0 python cannot use root for building envoy
 RUN groupadd --gid 777 -f envoygroup \
-  && useradd -o --uid 777 --gid 777 --no-create-home --home-dir /build envoybuild \
+  && (id -u envoybuild >/dev/null 2>&1 || useradd -o --uid 777 --gid 777 --no-create-home --home-dir /build envoybuild) \
   && usermod -a -G pcap envoybuild \
-  && mkdir /build /source \
+  && mkdir -p /build /source \
   && chown -R envoybuild:envoygroup /build /source
 
 COPY --chown=envoybuild:envoygroup . /envoy-sources/

--- a/scripts/Dockerfile.build-ubuntu
+++ b/scripts/Dockerfile.build-ubuntu
@@ -6,7 +6,7 @@ ARG BUILD_CMD
 # since 1.27.0 python cannot use root for building envoy
 RUN groupadd --gid 777 -f envoygroup \
   && (id -u envoybuild >/dev/null 2>&1 || useradd -o --uid 777 --gid 777 --no-create-home --home-dir /build envoybuild) \
-  && usermod -a -G pcap envoybuild \
+  && (getent group pcap >/dev/null && usermod -a -G pcap envoybuild || true) \
   && mkdir -p /build /source \
   && chown -R envoybuild:envoygroup /build /source
 

--- a/scripts/Dockerfile.build-ubuntu
+++ b/scripts/Dockerfile.build-ubuntu
@@ -3,6 +3,11 @@ FROM $ENVOY_BUILD_IMAGE
 
 ARG BUILD_CMD
 
+# binutils (strip) is not in the ci-variant build images shipped from v1.37+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends binutils \
+  && rm -rf /var/lib/apt/lists/*
+
 # since 1.27.0 python cannot use root for building envoy
 RUN groupadd --gid 777 -f envoygroup \
   && (id -u envoybuild >/dev/null 2>&1 || useradd -o --uid 777 --gid 777 --no-create-home --home-dir /build envoybuild) \

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -29,7 +29,11 @@ ENVOY_BUILD_CONFIG=$(curl --fail --location --silent https://raw.githubuserconte
 ENVOY_BUILD_REPO=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  repo:/ {print $2; exit}')
 ENVOY_BUILD_TAG=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  tag:/ {print $2; exit}')
 ENVOY_BUILD_SHA=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  sha:/ {print $2; exit}')
-ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO:-docker.io/envoyproxy/envoy-build}:${ENVOY_BUILD_TAG}@sha256:${ENVOY_BUILD_SHA}"
+# v1.37+ split envoy-build into variants; "ci" is the standard build image.
+if [[ "${ENVOY_BUILD_REPO}" != *envoy-build-ubuntu ]]; then
+  ENVOY_BUILD_TAG="ci-${ENVOY_BUILD_TAG}"
+fi
+ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO}:${ENVOY_BUILD_TAG}@sha256:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
 docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -26,9 +26,10 @@ popd
 BUILD_CMD=${BUILD_CMD:-"bazel build ${BAZEL_BUILD_OPTIONS[@]} -c opt ${BUILD_TARGET} ${CONTRIB_ENABLED_ARGS} --//source/extensions/transport_sockets/tcp_stats:enabled=false"}
 
 ENVOY_BUILD_CONFIG=$(curl --fail --location --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.github/config.yml)
+ENVOY_BUILD_REPO=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  repo:/ {print $2; exit}')
 ENVOY_BUILD_TAG=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  tag:/ {print $2; exit}')
 ENVOY_BUILD_SHA=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  sha:/ {print $2; exit}')
-ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-ubuntu:${ENVOY_BUILD_TAG}@sha256:${ENVOY_BUILD_SHA}"
+ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO:-docker.io/envoyproxy/envoy-build}:${ENVOY_BUILD_TAG}@sha256:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
 docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -36,8 +36,9 @@ popd
 BUILD_CMD=${BUILD_CMD:-"bazel build ${BAZEL_BUILD_OPTIONS[@]} -c opt ${BUILD_TARGET} ${CONTRIB_ENABLED_ARGS}"}
 
 ENVOY_BUILD_CONFIG=$(curl --fail --location --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.github/config.yml)
+ENVOY_BUILD_REPO=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  repo:/ {print $2; exit}')
 ENVOY_BUILD_TAG=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  tag:/ {print $2; exit}')
-ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-ubuntu:${ENVOY_BUILD_TAG}"
+ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO:-docker.io/envoyproxy/envoy-build}:${ENVOY_BUILD_TAG}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
 echo "BUILD_CMD=${BUILD_CMD}"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -38,7 +38,11 @@ BUILD_CMD=${BUILD_CMD:-"bazel build ${BAZEL_BUILD_OPTIONS[@]} -c opt ${BUILD_TAR
 ENVOY_BUILD_CONFIG=$(curl --fail --location --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.github/config.yml)
 ENVOY_BUILD_REPO=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  repo:/ {print $2; exit}')
 ENVOY_BUILD_TAG=$(echo "${ENVOY_BUILD_CONFIG}" | awk '/^  tag:/ {print $2; exit}')
-ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO:-docker.io/envoyproxy/envoy-build}:${ENVOY_BUILD_TAG}"
+# v1.37+ split envoy-build into variants; "ci" is the standard build image.
+if [[ "${ENVOY_BUILD_REPO}" != *envoy-build-ubuntu ]]; then
+  ENVOY_BUILD_TAG="ci-${ENVOY_BUILD_TAG}"
+fi
+ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO}:${ENVOY_BUILD_TAG}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
 echo "BUILD_CMD=${BUILD_CMD}"


### PR DESCRIPTION
 Envoy renamed the build image from `envoyproxy/envoy-build-ubuntu` to
  `envoyproxy/envoy-build` in v1.37. Both build scripts hardcoded the old
  name, so `make build/envoy` against `main` (and any v1.37+ tag) fails:

  envoyproxy/envoy-build-ubuntu:v0.1.3: not found

  Read `repo:` from upstream `.github/config.yml` instead of hardcoding.
  Verified the field exists in every release from v1.30 onward, so older
  versions keep working.