### PR TITLE
build(build): fix linux build for envoy 1.39

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -19,6 +19,7 @@ patch_per_version[v1.35]="$()"
 patch_per_version[v1.36]="$()"
 patch_per_version[v1.37]="$(realpath "patches/main-0001-linux-dockerfile-build-ubuntu.patch")"
 patch_per_version[v1.38]="$(realpath "patches/main-0001-linux-dockerfile-build-ubuntu.patch")"
+patch_per_version[v1.39]="$(realpath "patches/main-0001-linux-dockerfile-build-ubuntu.patch")"
 
 BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:-""}
 read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS}"

--- a/scripts/fetch_sources.sh
+++ b/scripts/fetch_sources.sh
@@ -16,6 +16,7 @@ patches_per_version[v1.35]="$()"
 patches_per_version[v1.36]="$()"
 patches_per_version[v1.37]="$()"
 patches_per_version[v1.38]="$()"
+patches_per_version[v1.39]="$()"
 
 declare -A patches_darwin
 patches_darwin[v1.34]="$(realpath "patches/v1.34-0001-darwin-patch-lua.patch")"
@@ -23,6 +24,7 @@ patches_darwin[v1.35]="$(realpath "patches/v1.35-0001-darwin-patch-lua.patch")"
 patches_darwin[v1.36]="$(realpath "patches/v1.36-0001-darwin-patch-lua.patch")"
 patches_darwin[v1.37]="$()"
 patches_darwin[v1.38]="$()"
+patches_darwin[v1.39]="$()"
 
 # clone Envoy repo if not exists
 if [[ ! -d "${SOURCE_DIR}" ]]; then


### PR DESCRIPTION
> Changelog: skip

## Motivation

Building envoy 1.39 on linux fails in the Docker step:

```text
bash: line 1: bazel/setup_clang.sh: No such file or directory
exit code: 127
```

`scripts/build_linux.sh` resolves a Dockerfile patch by version key (`v1.39.0` becomes `v1.39`). The `patch_per_version` map had `main`, `v1.37` and `v1.38` but no `v1.39`, so the lookup missed and no patch was applied.

That patch (`patches/main-0001-linux-dockerfile-build-ubuntu.patch`) exists solely to drop the `bazel/setup_clang.sh /opt/llvm` line from `Dockerfile.build-ubuntu`. Envoy no longer ships that script in the `ci-` variant build images used from v1.37 onward, where clang is preconfigured. That is why v1.37 and v1.38 already apply it. Without the patch the line survived into the build and hit a missing file.

## Implementation information

- `scripts/build_linux.sh`: add `patch_per_version[v1.39]`, same patch as v1.37 and v1.38.
- `scripts/fetch_sources.sh`: add empty `v1.39` keys to `patches_per_version` and `patches_darwin`. These maps default to an empty string on a miss so they were not causing failures. Added to keep the version keys consistent across the gating maps.

Linux only. The other gates are numeric comparisons (Makefile FIPS `>= 38`, the darwin gates in `build-github.yaml`) and cover 1.39.

## Verification

- Patch dry-runs cleanly against the current `Dockerfile.build-ubuntu`.
- Simulated the key derivation: `v1.39.0` and `v1.39.5` both resolve to the patch.
- Full Docker build not run, that is a multi-hour compile. Worth a real build leg before merge:

```sh
gh workflow run build.yaml -f os=linux -f arch=amd64 -f version=1.39.0
```

## Note

`shellcheck` flags SC2178 and SC2128 in `fetch_sources.sh` (lines 60-62, `patches` reused as both array and string). Pre-existing, confirmed against a clean tree. A multi-patch entry would silently apply only the first patch, but every current entry is empty or single-patch. Left alone here, worth a separate fix.
