### PR TITLE
build(build): fix linux build out of disk space

### DIFF
--- a/scripts/Dockerfile.build-centos
+++ b/scripts/Dockerfile.build-centos
@@ -1,5 +1,5 @@
 ARG ENVOY_BUILD_IMAGE
-FROM $ENVOY_BUILD_IMAGE
+FROM $ENVOY_BUILD_IMAGE AS builder
 
 ARG BUILD_CMD
 
@@ -13,3 +13,11 @@ COPY . /envoy-sources/
 RUN bash -c "pushd envoy-sources/ && bazel/setup_clang.sh /opt/llvm"
 RUN bash -c "pushd /envoy-sources && $BUILD_CMD"
 RUN bash -c "pushd /envoy-sources/bazel-bin/contrib/exe && strip envoy-static -o envoy"
+
+# resolve the bazel-bin symlink so the binary sits at a real path for COPY --from
+RUN cp -L /envoy-sources/bazel-bin/contrib/exe/envoy /envoy
+
+# Exported with `--output type=local`: only the binary leaves the builder, so the
+# multi-GB bazel tree is never exported and unpacked into the docker image store.
+FROM scratch AS binary
+COPY --from=builder /envoy /envoy

--- a/scripts/Dockerfile.build-ubuntu
+++ b/scripts/Dockerfile.build-ubuntu
@@ -1,5 +1,5 @@
 ARG ENVOY_BUILD_IMAGE
-FROM $ENVOY_BUILD_IMAGE
+FROM $ENVOY_BUILD_IMAGE AS builder
 
 ARG BUILD_CMD
 
@@ -20,3 +20,11 @@ COPY --chown=envoybuild:envoygroup . /envoy-sources/
 RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && bazel/setup_clang.sh /opt/llvm"
 RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && $BUILD_CMD"
 RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources/bazel-bin/contrib/exe && strip envoy-static -o envoy"
+
+# resolve the bazel-bin symlink so the binary sits at a real path for COPY --from
+RUN cp -L /envoy-sources/bazel-bin/contrib/exe/envoy /envoy
+
+# Exported with `--output type=local`: only the binary leaves the builder, so the
+# multi-GB bazel tree is never exported and unpacked into the docker image store.
+FROM scratch AS binary
+COPY --from=builder /envoy /envoy

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -34,14 +34,15 @@ if [[ "${ENVOY_BUILD_REPO}" != *envoy-build-ubuntu ]]; then
   ENVOY_BUILD_TAG="ci-${ENVOY_BUILD_TAG}"
 fi
 ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO}:${ENVOY_BUILD_TAG}@sha256:${ENVOY_BUILD_SHA}"
-LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
-docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
+# Export only the "binary" stage to the host: tagging the builder would make docker
+# export and unpack the whole bazel tree, which needs tens of GB of extra disk.
+OUTPUT_DIR=$(mktemp -d)
+trap 'rm -rf "${OUTPUT_DIR}"' EXIT
+
+docker build --target binary --output "type=local,dest=${OUTPUT_DIR}" --progress=plain \
   --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
   --build-arg BUILD_CMD="${BUILD_CMD}" \
   -f scripts/Dockerfile.build-centos "${SOURCE_DIR}"
 
-# copy out the binary
-id=$(docker create "${LOCAL_BUILD_IMAGE}")
-docker cp "$id":/envoy-sources/bazel-bin/contrib/exe/envoy "${BINARY_PATH}"
-docker rm -v "$id"
+mv "${OUTPUT_DIR}/envoy" "${BINARY_PATH}"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -44,7 +44,6 @@ if [[ "${ENVOY_BUILD_REPO}" != *envoy-build-ubuntu ]]; then
   ENVOY_BUILD_TAG="ci-${ENVOY_BUILD_TAG}"
 fi
 ENVOY_BUILD_IMAGE="${ENVOY_BUILD_REPO}:${ENVOY_BUILD_TAG}"
-LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 
 echo "BUILD_CMD=${BUILD_CMD}"
 
@@ -68,12 +67,14 @@ if [[ -v patch_per_version["${VERSION_KEY}"] ]]; then
   fi
 fi
 
-docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
+# Export only the "binary" stage to the host: tagging the builder would make docker
+# export and unpack the whole bazel tree, which needs tens of GB of extra disk.
+OUTPUT_DIR=$(mktemp -d)
+trap 'rm -rf "${OUTPUT_DIR}"' EXIT
+
+docker build --target binary --output "type=local,dest=${OUTPUT_DIR}" --progress=plain \
   --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
   --build-arg BUILD_CMD="${BUILD_CMD}" \
   -f "scripts/Dockerfile.build-ubuntu" "${SOURCE_DIR}"
 
-# copy out the binary
-id=$(docker create "${LOCAL_BUILD_IMAGE}")
-docker cp "$id":/envoy-sources/bazel-bin/contrib/exe/envoy "${BINARY_PATH}"
-docker rm -v "$id"
+mv "${OUTPUT_DIR}/envoy" "${BINARY_PATH}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -107,7 +107,8 @@ resource "aws_instance" "envoy-ci-build" {
   }
 
   root_block_device {
-    volume_size = "100"
+    # bazel's output tree plus the buildkit cache outgrew 100GB on linux/amd64
+    volume_size = "200"
   }
 
   subnet_id = data.aws_subnet.exisiting_subnet.id


### PR DESCRIPTION
> Changelog: skip

## Motivation

Both linux/amd64 legs of [run 30786373293](https://github.com/kumahq/envoy-builds/actions/runs/30786373293) failed with `write /home/admin/envoy-builds/build/artifacts-linux-amd64/envoy/envoy-main+fips: no space left on device` after a successful 82-minute bazel build.

Envoy is compiled inside the docker image, so tagging the builder makes docker keep three copies of the multi-GB bazel output tree on the 100GB root volume: the buildkit snapshots, the exported layer blobs, and the unpacked image snapshot. The job log shows `exporting layers 1188.3s` followed by `unpacking to docker.io/library/envoy-builder:main 481.5s` — by the time `docker cp` tried to write the 120MB binary out, the disk was full. arm64 fit within the volume; both amd64 legs did not.

## Implementation information

`Dockerfile.build-ubuntu` and `Dockerfile.build-centos` gain a `FROM scratch AS binary` stage holding only the stripped binary, and `build_linux.sh` / `build_centos.sh` extract it with `docker build --target binary --output type=local` instead of tagging the builder and running `docker create` + `docker cp`. Nothing but the binary leaves buildkit, so the layer export and image unpack never happen — which also cuts ~48 minutes off every linux build. A `cp -L` in the builder resolves the `bazel-bin` symlink so the binary sits at a real path for `COPY --from`. The EC2 root volume goes from 100GB to 200GB for headroom, since the bazel tree plus the buildkit cache keeps growing on its own.

## Supporting documentation

shellcheck is clean on both scripts, `main-0001-linux-dockerfile-build-ubuntu.patch` still applies (dry-run), and `terraform validate` passes. The `--target binary --output type=local` pattern was smoke-tested against real docker, including symlink resolution and executable-bit preservation on the exported file. A full linux build has not been run yet — that needs a CI leg.